### PR TITLE
Assigns unique class A IP addresses to alias on loopback interfaces

### DIFF
--- a/roles/vethcon-configure/tasks/main.yml
+++ b/roles/vethcon-configure/tasks/main.yml
@@ -67,18 +67,18 @@
 - name: Create aliases for Class A IP addresses
   shell: >
     docker exec -i {{ item.container }} /bin/bash -c '
-    ip a add {{ item.ip_address }}/255.255.255.0 dev {{ item.interface }};
+    ip a add {{ item.ip_address }}/255.255.255.255 dev lo;
     '    
   with_items:
     - container: centos_a
-      interface: in1
+      # interface: in1
       ip_address: 1.1.1.1
     - container: quagga_a
-      interface: in2
+      # interface: in2
       ip_address: 2.2.2.2
     - container: quagga_b
-      interface: out1
+      # interface: out1
       ip_address: 3.3.3.3
     - container: centos_b
-      interface: out2
+      # interface: out2
       ip_address: 4.4.4.4


### PR DESCRIPTION
From Ajay:

> We can do it this way for all IDs. If it is on loopback it won't go down.

His console output:

```
[centos@centos-host ~]$  docker exec -it centos_a /bin/bash
Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.26/containers/centos_a/exec: dial unix /var/run/docker.sock: connect: permission denied
[centos@centos-host ~]$ sudo  docker exec -it centos_a /bin/bash
[root@centos_a /]# ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
59: in1@if58: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP 
    link/ether 26:eb:02:ca:ba:0a brd ff:ff:ff:ff:ff:ff link-netnsid 1
    inet 192.168.2.100/24 scope global in1
       valid_lft forever preferred_lft forever
    inet 1.1.1.1/24 scope global in1
       valid_lft forever preferred_lft forever
    inet6 fe80::24eb:2ff:feca:ba0a/64 scope link 
       valid_lft forever preferred_lft forever
[root@centos_a /]# ifconfig lo:1 11.11.11.11 netmask 255.255.255.255 up
[root@centos_a /]# ifconfig lo:1
lo:1: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 11.11.11.11  netmask 255.255.255.255
        loop  txqueuelen 1  (Local Loopback)
```
