### PR TITLE
Update to latest koko

### DIFF
--- a/roles/build-quagga/templates/Dockerfile.j2
+++ b/roles/build-quagga/templates/Dockerfile.j2
@@ -5,10 +5,10 @@ MAINTAINER @dougbtv
 ENV build_date 2017-03-27
 RUN yum update -y && \
     yum install -y tcpdump iproute traceroute initscripts json-c redhat-lsb-core
-ADD http://cumulusfiles.s3.amazonaws.com/roh-rhel7.tar /tmp/roh.tar
+ADD http://cumulusfiles.s3.amazonaws.com/roh-3.2.1-rhel7.tar /tmp/roh.tar
 WORKDIR /tmp
 RUN tar -xvf roh.tar && \
-    target=$(find rhel7/ | grep -P "rhel7/quagga\-\d") && \
+    target=$(find . | grep -P "quagga\-\d") && \
     rpm -ivh $target
 WORKDIR /
 ADD entrypoint.sh /entrypoint.sh

--- a/roles/koko-compile/tasks/main.yml
+++ b/roles/koko-compile/tasks/main.yml
@@ -4,10 +4,24 @@
   yum:
     name: "{{ item }}"
   with_items:
-    - golang 
     - nano 
     - tree 
     - git
+
+- name: Import go-repo.io gpg keys
+  shell: >
+    rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO
+
+- name: Add custom go-repo.io
+  yum_repository:
+    name: go-repo
+    description: Latest Go Lang repo
+    baseurl: https://mirror.go-repo.io/centos/$releasever/$basearch/
+
+- name: Install go
+  yum:
+    name: golang
+    state: present
 
 - name: Setup environment variables
   set_fact:

--- a/roles/koko-configure/tasks/main.yml
+++ b/roles/koko-configure/tasks/main.yml
@@ -33,20 +33,20 @@
 - name: Create ingress interfaces
   shell: >
     /usr/src/gocode/koko 
-    -d {{ id_centos_a.stdout }}:in1:192.168.2.100/24
-    -d {{ id_quagga_a.stdout }}:in2:192.168.2.101/24
+    -d {{ id_centos_a.stdout }},in1,192.168.2.100/24
+    -d {{ id_quagga_a.stdout }},in2,192.168.2.101/24
 
 - name: Create middle interfaces
   shell: >
     /usr/src/gocode/koko 
-    -d {{ id_quagga_a.stdout }}:mid1:192.168.3.100/24
-    -d {{ id_quagga_b.stdout }}:mid2:192.168.3.101/24
+    -d {{ id_quagga_a.stdout }},mid1,192.168.3.100/24
+    -d {{ id_quagga_b.stdout }},mid2,192.168.3.101/24
 
 - name: Create egress interfaces
   shell: >
     /usr/src/gocode/koko 
-    -d {{ id_quagga_b.stdout }}:out1:192.168.4.100/24
-    -d {{ id_centos_b.stdout }}:out2:192.168.4.101/24
+    -d {{ id_quagga_b.stdout }},out1,192.168.4.100/24
+    -d {{ id_centos_b.stdout }},out2,192.168.4.101/24
 
 # [root@cd23ab1e4135 /]# ip link set dev test2 up
 # [root@cd23ab1e4135 /]# ip a add 192.168.5.200/255.255.255.0 dev test2

--- a/roles/koko-vxlan-configure/tasks/main.yml
+++ b/roles/koko-vxlan-configure/tasks/main.yml
@@ -12,8 +12,8 @@
 - name: Create veth interfaces
   shell: >
     /usr/src/gocode/koko 
-    -d {{ endpoint.container_name }}:{{ endpoint.ifname }}:{{ endpoint.ipaddr }}/24
-    -d {{ router_veth.container_name }}:{{ router_veth.ifname }}:{{ router_veth.ipaddr }}/24
+    -d {{ endpoint.container_name }},{{ endpoint.ifname }},{{ endpoint.ipaddr }}/24
+    -d {{ router_veth.container_name }},{{ router_veth.ifname }},{{ router_veth.ipaddr }}/24
 
 # vxlan example.
 # ./koko {-d <container>:<linkname>[:<IPv4 addr>/<prefixlen>] |
@@ -23,8 +23,8 @@
 - name: Create middle (vxlan) interfaces
   shell: >
     /usr/src/gocode/koko 
-    -d {{ router_vxlan.container_name }}:{{ router_vxlan.ifname }}:{{ router_vxlan.ipaddr }}/24
-    -x eth0:{{ router_vxlan.remote_ipaddr }}:{{ vxlan_id }}
+    -d {{ router_vxlan.container_name }},{{ router_vxlan.ifname }},{{ router_vxlan.ipaddr }}/24
+    -x eth0,{{ router_vxlan.remote_ipaddr }},{{ vxlan_id }}
 
 - name: Set endpoint default routes
   shell: >

--- a/roles/quagga-run/tasks/main.yml
+++ b/roles/quagga-run/tasks/main.yml
@@ -37,8 +37,9 @@
   ignore_errors: yes
 
 - name: Get list of running containers
+  # Single quotes were messing up my conditional below...
   shell: >
-    docker ps -a
+    docker ps -a | sed -e "s/'//"
   register: docker_psa
 
 - name: Default volume fact


### PR DESCRIPTION
Recent koko changes were breaking, including:

* requires go 1.7 (due to deps)
* syntax changes in command line args (uses commas now instead of colons)

Some other bug fixes
* URL for cumulus quagga rpms had changed
* errant single quotes in `docker ps` output broke conditionals