### PR TITLE
Updates for ansible 2.3, pins koko at v0.4

### DIFF
--- a/inventory/vxlan.lab.inventory
+++ b/inventory/vxlan.lab.inventory
@@ -1,5 +1,5 @@
-host_a ansible_host=192.168.1.88
-host_b ansible_host=192.168.1.229
+host_a ansible_host=192.168.1.66
+host_b ansible_host=192.168.1.185
 
 [all_vms]
 host_a

--- a/roles/docker-build-images/tasks/main.yml
+++ b/roles/docker-build-images/tasks/main.yml
@@ -18,12 +18,11 @@
 - name: Pull centos:centos7
   shell: >
     docker pull centos:centos7
-  when: "'centos7' not in '{{ image_list.stdout }}'"
+  when: "'centos7' not in image_list.stdout"
 
 - name: Build veth_centos
   shell: >
     docker build -t veth_centos .
   args:
     chdir: /usr/src/dockerfiles/veth_centos/
-  when: "'veth_centos' not in '{{ image_list.stdout }}'"    
-
+  when: "'veth_centos' not in image_list.stdout"

--- a/roles/koko-compile/tasks/main.yml
+++ b/roles/koko-compile/tasks/main.yml
@@ -38,7 +38,7 @@
   git:
     repo: 'https://github.com/redhat-nfvpe/koko.git'
     dest: /usr/src/gocode/src/koko/
-    version: master
+    version: v0.4
 
 - name: Resolve koko dependencies
   shell: >

--- a/roles/quagga-run/tasks/main.yml
+++ b/roles/quagga-run/tasks/main.yml
@@ -20,11 +20,6 @@
     docker images
   register: docker_images
 
-# - name: Pull quagga when not found
-#   shell: >
-#     docker pull cumulusnetworks/quagga:xenial-latest
-#   when: "'cumulusnetworks/quagga' not in '{{ docker_images.stdout }}'"
-
 - name: Always setup iptables forwarding rules
   shell: >
     iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE &&
@@ -33,7 +28,7 @@
 - name: Kill and remove quagga, conditionally
   shell: >
     docker kill {{ quagga_container_name }}
-  when: "{{force_quagga_kill}}"
+  when: "force_quagga_kill"
   ignore_errors: yes
 
 - name: Get list of running containers
@@ -63,7 +58,6 @@
     --privileged 
     --net none 
     {{ quagga_image_name }}
-  # when: "'{{ quagga_container_name }}' not in '{{ docker_psa.stdout }}'"
 
 - name: set quagga static routes
   shell: >
@@ -75,21 +69,3 @@
     -c 'redistribute stat'
   with_items: "{{ quagga_static_route }}"
 
-# Quagga has some problems here, they're not using a single process in the foreground
-# So we have to baby starting it up
-# So let's list the processes in the container and start up quagga if need be
-
-# - name: Install packages when debug is enabled
-#   shell: >
-#     docker exec -i {{ quagga_container_name }} /bin/bash -c 'apt-get update && apt-get -y install inetutils-ping net-tools tcpdump'
-#   when: quagga_debug is defined
-
-# - name: List processes in container
-#   shell: >
-#     docker exec -i {{ quagga_container_name }} ps ax
-#   register: quagga_ps
-
-# - name: Run quagga in the container via exec
-#   shell: >
-#     docker exec -i {{ quagga_container_name }} /usr/lib/quagga/quagga start
-#   when: "'zebra' not in '{{ quagga_ps.stdout }}'"

--- a/roles/vm-spinup/tasks/main.yml
+++ b/roles/vm-spinup/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Run spinup for each host that doesn't exist
   shell: >
     /root/spinup.sh {{ item }}
-  when: "'{{ item }}' not in '{{ virsh_list.stdout }}'"
+  when: "item not in virsh_list.stdout"
   with_items: "{{ virtual_machines }}"
 
 - name: Get IP Addresses for all VMs


### PR DESCRIPTION
Koko wasn't compiling using current scheme, had to revert to v0.4, should be sufficient as really the only requirement here that I'm looking for at this time is the vxlan functionality.

Additionally, conditionals were failing under ansible 2.3 so, they have been updated.